### PR TITLE
Bump tokio-modbus to 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,15 +10,16 @@ edition = "2018"
 
 [dependencies]
 log = "0.4"
+thiserror = "2.0.12"
 ur20 = "0.5"
 
 [dependencies.tokio-modbus]
-version = "0.4"
+version = "0.16.1"
 default-features = false
 features = ["tcp"]
 
 [dev-dependencies]
-tokio = { version = "0.2", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 
 [badges]
 travis-ci = { repository = "slowtec/ur20-modbus" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,7 +205,7 @@ impl Coupler {
     }
 
     fn next_out(&mut self, input: &[u16], output: &[u16]) -> Result<Vec<u16>> {
-        self.coupler.next(&input, &output).map_err(Error::Ur20Error)
+        self.coupler.next(input, output).map_err(Error::Ur20Error)
     }
 
     async fn write(&mut self, output: &[u16]) -> Result<()> {
@@ -311,7 +311,7 @@ async fn read_process_output_register_count(client: &mut Client) -> Result<u16> 
 async fn read_parameters(client: &mut Client, module_list: &[ModuleType]) -> Result<Vec<Vec<u16>>> {
     debug!("read parameters");
     let mut params = vec![];
-    for (addr, reg_cnt) in &param_addresses_and_register_counts(&module_list) {
+    for (addr, reg_cnt) in &param_addresses_and_register_counts(module_list) {
         params.push(if *reg_cnt == 0 {
             vec![]
         } else {


### PR DESCRIPTION
Hi, because the current version uses tokio-modbus which then depends on tokio 0.2 this crate is incompatible with my setup. I would therefore like to bump the tokio-modbus version.

For this end, I added an error type and piped all errors and exceptions to the user. Maybe this is debatable.

Also, I haven't been able to test this.